### PR TITLE
Fix link to Apache License in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Full list and attributions are in [ICONS.md](./ICONS.md).
 
 ## License
 This project is licensed under Apache-2.0.
-- [Apache License 2.0](./LICENSE-Apache)
+- [Apache License 2.0](./LICENSE)
 
 ### Third Party Licenses
 - [See here](./THIRD_PARTY_LICENSES.md)


### PR DESCRIPTION
Updated the link to the Apache License in the README.